### PR TITLE
fix: fix typo in automation runbook abbreviation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -196,10 +196,10 @@ locals {
       regex       = "^[^<>*%:.?\\+\\/]+[^<>*%:.?\\+\\/ ]$"
     }
     automation_runbook = {
-      name        = substr(join("-", compact([local.prefix, "aacred", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "aacred", local.suffix_unique])), 0, 63)
+      name        = substr(join("-", compact([local.prefix, "aarun", local.suffix])), 0, 63)
+      name_unique = substr(join("-", compact([local.prefix, "aarun", local.suffix_unique])), 0, 63)
       dashes      = true
-      slug        = "aacred"
+      slug        = "aarun"
       min_length  = 1
       max_length  = 63
       scope       = "parent"

--- a/resourceDefinition.json
+++ b/resourceDefinition.json
@@ -172,7 +172,7 @@
     },
     "regex": "^(?=.{1,63}$)[a-zA-Z][a-zA-Z0-9-]+$",
     "scope": "parent",
-    "slug": "aacred",
+    "slug": "aarun",
     "dashes": true
   },
   {


### PR DESCRIPTION
## Description

This PR fixes a typo in the automation runbook abbreviation.

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)
