### PR TITLE
fix: remove legacy cdn endpoint and profile resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,6 @@ No modules.
 | <a name="output_bot_channels_registration"></a> [bot\_channels\_registration](#output\_bot\_channels\_registration) | Bot Channels Registration |
 | <a name="output_bot_connection"></a> [bot\_connection](#output\_bot\_connection) | Bot Connection |
 | <a name="output_bot_web_app"></a> [bot\_web\_app](#output\_bot\_web\_app) | Bot Web App |
-| <a name="output_cdn_endpoint"></a> [cdn\_endpoint](#output\_cdn\_endpoint) | Cdn Endpoint |
 | <a name="output_cdn_frontdoor_custom_domain"></a> [cdn\_frontdoor\_custom\_domain](#output\_cdn\_frontdoor\_custom\_domain) | Cdn Frontdoor Custom Domain |
 | <a name="output_cdn_frontdoor_endpoint"></a> [cdn\_frontdoor\_endpoint](#output\_cdn\_frontdoor\_endpoint) | Cdn Frontdoor Endpoint |
 | <a name="output_cdn_frontdoor_firewall_policy"></a> [cdn\_frontdoor\_firewall\_policy](#output\_cdn\_frontdoor\_firewall\_policy) | Cdn Frontdoor Firewall Policy |
@@ -120,7 +119,6 @@ No modules.
 | <a name="output_cdn_frontdoor_rule_set"></a> [cdn\_frontdoor\_rule\_set](#output\_cdn\_frontdoor\_rule\_set) | Cdn Frontdoor Rule Set |
 | <a name="output_cdn_frontdoor_secret"></a> [cdn\_frontdoor\_secret](#output\_cdn\_frontdoor\_secret) | Cdn Frontdoor Secret |
 | <a name="output_cdn_frontdoor_security_policy"></a> [cdn\_frontdoor\_security\_policy](#output\_cdn\_frontdoor\_security\_policy) | Cdn Frontdoor Security Policy |
-| <a name="output_cdn_profile"></a> [cdn\_profile](#output\_cdn\_profile) | Cdn Profile |
 | <a name="output_cognitive_account"></a> [cognitive\_account](#output\_cognitive\_account) | Cognitive Account |
 | <a name="output_cognitive_deployment"></a> [cognitive\_deployment](#output\_cognitive\_deployment) | Cognitive Deployment |
 | <a name="output_communication_service"></a> [communication\_service](#output\_communication\_service) | Communication Service |

--- a/main.tf
+++ b/main.tf
@@ -435,16 +435,6 @@ locals {
       scope       = "global"
       regex       = "^[a-zA-Z0-9][a-zA-Z0-9-._]{1,62}[a-zA-Z0-9]$"
     }
-    cdn_endpoint = {
-      name        = substr(join("-", compact([local.prefix, "cdn", local.suffix])), 0, 50)
-      name_unique = substr(join("-", compact([local.prefix, "cdn", local.suffix_unique])), 0, 50)
-      dashes      = true
-      slug        = "cdn"
-      min_length  = 1
-      max_length  = 50
-      scope       = "global"
-      regex       = "^[a-zA-Z0-9][a-zA-Z0-9-]{0,48}[a-zA-Z0-9]$"
-    }
     cdn_frontdoor_custom_domain = {
       name        = substr(join("-", compact([local.prefix, "cfdcd", local.suffix])), 0, 260)
       name_unique = substr(join("-", compact([local.prefix, "cfdcd", local.suffix_unique])), 0, 260)
@@ -554,16 +544,6 @@ locals {
       max_length  = 260
       scope       = "parent"
       regex       = "^[0-9A-Za-z_-]{1,260}$"
-    }
-    cdn_profile = {
-      name        = substr(join("-", compact([local.prefix, "cdnprof", local.suffix])), 0, 260)
-      name_unique = substr(join("-", compact([local.prefix, "cdnprof", local.suffix_unique])), 0, 260)
-      dashes      = true
-      slug        = "cdnprof"
-      min_length  = 1
-      max_length  = 260
-      scope       = "resourceGroup"
-      regex       = "^[a-zA-Z0-9][a-zA-Z0-9-]{0,258}[a-zA-Z0-9]$"
     }
     cognitive_account = {
       name        = substr(join("-", compact([local.prefix, "cog", local.suffix])), 0, 64)
@@ -3707,10 +3687,6 @@ locals {
       valid_name        = length(regexall(local.az.bot_web_app.regex, local.az.bot_web_app.name)) > 0 && length(local.az.bot_web_app.name) > local.az.bot_web_app.min_length
       valid_name_unique = length(regexall(local.az.bot_web_app.regex, local.az.bot_web_app.name_unique)) > 0
     }
-    cdn_endpoint = {
-      valid_name        = length(regexall(local.az.cdn_endpoint.regex, local.az.cdn_endpoint.name)) > 0 && length(local.az.cdn_endpoint.name) > local.az.cdn_endpoint.min_length
-      valid_name_unique = length(regexall(local.az.cdn_endpoint.regex, local.az.cdn_endpoint.name_unique)) > 0
-    }
     cdn_frontdoor_custom_domain = {
       valid_name        = length(regexall(local.az.cdn_frontdoor_custom_domain.regex, local.az.cdn_frontdoor_custom_domain.name)) > 0 && length(local.az.cdn_frontdoor_custom_domain.name) > local.az.cdn_frontdoor_custom_domain.min_length
       valid_name_unique = length(regexall(local.az.cdn_frontdoor_custom_domain.regex, local.az.cdn_frontdoor_custom_domain.name_unique)) > 0
@@ -3754,10 +3730,6 @@ locals {
     cdn_frontdoor_security_policy = {
       valid_name        = length(regexall(local.az.cdn_frontdoor_security_policy.regex, local.az.cdn_frontdoor_security_policy.name)) > 0 && length(local.az.cdn_frontdoor_security_policy.name) > local.az.cdn_frontdoor_security_policy.min_length
       valid_name_unique = length(regexall(local.az.cdn_frontdoor_security_policy.regex, local.az.cdn_frontdoor_security_policy.name_unique)) > 0
-    }
-    cdn_profile = {
-      valid_name        = length(regexall(local.az.cdn_profile.regex, local.az.cdn_profile.name)) > 0 && length(local.az.cdn_profile.name) > local.az.cdn_profile.min_length
-      valid_name_unique = length(regexall(local.az.cdn_profile.regex, local.az.cdn_profile.name_unique)) > 0
     }
     cognitive_account = {
       valid_name        = length(regexall(local.az.cognitive_account.regex, local.az.cognitive_account.name)) > 0 && length(local.az.cognitive_account.name) > local.az.cognitive_account.min_length

--- a/outputs.tf
+++ b/outputs.tf
@@ -206,11 +206,6 @@ output "bot_web_app" {
   description = "Bot Web App"
 }
 
-output "cdn_endpoint" {
-  value       = local.az.cdn_endpoint
-  description = "Cdn Endpoint"
-}
-
 output "cdn_frontdoor_custom_domain" {
   value       = local.az.cdn_frontdoor_custom_domain
   description = "Cdn Frontdoor Custom Domain"
@@ -264,11 +259,6 @@ output "cdn_frontdoor_secret" {
 output "cdn_frontdoor_security_policy" {
   value       = local.az.cdn_frontdoor_security_policy
   description = "Cdn Frontdoor Security Policy"
-}
-
-output "cdn_profile" {
-  value       = local.az.cdn_profile
-  description = "Cdn Profile"
 }
 
 output "cognitive_account" {

--- a/resourceDefinition.yaml
+++ b/resourceDefinition.yaml
@@ -385,24 +385,6 @@
   slug: cfdsp
   dashes: true
 
-- name: cdn_profile
-  length:
-    min: 1
-    max: 260
-  regex: '^[a-zA-Z0-9][a-zA-Z0-9-]{0,258}[a-zA-Z0-9]$'
-  scope: resourceGroup
-  slug: cdnprof
-  dashes: true
-
-- name: cdn_endpoint
-  length:
-    min: 1
-    max: 50
-  regex: '^[a-zA-Z0-9][a-zA-Z0-9-]{0,48}[a-zA-Z0-9]$'
-  scope: global
-  slug: cdn
-  dashes: true
-
 - name: cognitive_account
   length:
     min: 2


### PR DESCRIPTION
## Description

This PR performs a cleanup of old legacy cdn profile resources

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)