### PR TITLE
fix: add support for sql managed instance naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,7 @@ No modules.
 | <a name="output_sql_elasticpool"></a> [sql\_elasticpool](#output\_sql\_elasticpool) | Sql Elasticpool |
 | <a name="output_sql_failover_group"></a> [sql\_failover\_group](#output\_sql\_failover\_group) | Sql Failover Group |
 | <a name="output_sql_firewall_rule"></a> [sql\_firewall\_rule](#output\_sql\_firewall\_rule) | Sql Firewall Rule |
+| <a name="output_sql_managed_instance"></a> [sql\_managed\_instance](#output\_sql\_managed\_instance) | Sql Managed Instance |
 | <a name="output_sql_server"></a> [sql\_server](#output\_sql\_server) | Sql Server |
 | <a name="output_storage_account"></a> [storage\_account](#output\_storage\_account) | Storage Account |
 | <a name="output_storage_blob"></a> [storage\_blob](#output\_storage\_blob) | Storage Blob |

--- a/main.tf
+++ b/main.tf
@@ -2945,6 +2945,16 @@ locals {
       scope       = "parent"
       regex       = "^[^<>*%:?\\\\+\\\\/]+[^<>*%:.?\\\\+\\\\/]$"
     }
+    sql_managed_instance = {
+      name        = substr(join("-", compact([local.prefix, "sqlmi", local.suffix])), 0, 63)
+      name_unique = substr(join("-", compact([local.prefix, "sqlmi", local.suffix_unique])), 0, 63)
+      dashes      = true
+      slug        = "sqlmi"
+      min_length  = 1
+      max_length  = 63
+      scope       = "global"
+      regex       = "^[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$"
+    }
     sql_server = {
       name        = substr(join("-", compact([local.prefix, "sql", local.suffix])), 0, 63)
       name_unique = substr(join("-", compact([local.prefix, "sql", local.suffix_unique])), 0, 63)
@@ -4700,6 +4710,10 @@ locals {
     sql_firewall_rule = {
       valid_name        = length(regexall(local.az.sql_firewall_rule.regex, local.az.sql_firewall_rule.name)) > 0 && length(local.az.sql_firewall_rule.name) > local.az.sql_firewall_rule.min_length
       valid_name_unique = length(regexall(local.az.sql_firewall_rule.regex, local.az.sql_firewall_rule.name_unique)) > 0
+    }
+    sql_managed_instance = {
+      valid_name        = length(regexall(local.az.sql_managed_instance.regex, local.az.sql_managed_instance.name)) > 0 && length(local.az.sql_managed_instance.name) > local.az.sql_managed_instance.min_length
+      valid_name_unique = length(regexall(local.az.sql_managed_instance.regex, local.az.sql_managed_instance.name_unique)) > 0
     }
     sql_server = {
       valid_name        = length(regexall(local.az.sql_server.regex, local.az.sql_server.name)) > 0 && length(local.az.sql_server.name) > local.az.sql_server.min_length

--- a/outputs.tf
+++ b/outputs.tf
@@ -1461,6 +1461,11 @@ output "sql_firewall_rule" {
   description = "Sql Firewall Rule"
 }
 
+output "sql_managed_instance" {
+  value       = local.az.sql_managed_instance
+  description = "Sql Managed Instance"
+}
+
 output "sql_server" {
   value       = local.az.sql_server
   description = "Sql Server"

--- a/resourceDefinition.yaml
+++ b/resourceDefinition.yaml
@@ -1816,6 +1816,16 @@
   slug: sql
   dashes: true
 
+- name: sql_managed_instance
+  length:
+    min: 1
+    max: 63
+  regex: '^[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$'
+  scope: global
+  slug: sqlmi
+  dashes: true
+
+
 - name: storage_account
   length:
     min: 3


### PR DESCRIPTION
## Description

Add sql managed instance naming


## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->

## Change Log

Add naming for sql managed instance:
* sql_managed_instance: sqlmi

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)